### PR TITLE
Remove duplicate tracks

### DIFF
--- a/src/app/components/play/play.component.ts
+++ b/src/app/components/play/play.component.ts
@@ -96,8 +96,10 @@ export class PlayComponent implements OnInit {
 
   appendTopTracks(topTracks: Track[]): void {
     topTracks.forEach((track: Track) => {
-      if (!this.topTracksMap.has(track.id)) {
-        this.topTracksMap.set(track.id, track);
+
+      const titleArtistsStr = track.name.concat(this.spotifyService.artistsToStr(track.artists));
+      if (track.preview_url && !this.topTracksMap.has(titleArtistsStr)) {
+        this.topTracksMap.set(titleArtistsStr, track);
       }
     });
   }


### PR DESCRIPTION
- Changed logic for adding tracks to the Map. Added a better check if it already exists and if it has a Spotify Preview URL (this is the `src` of the `<audio>` element)

- Done by changing the index used by the Track Map from the Id to a string combined from the track title and all of the track artists names